### PR TITLE
Fix JPEG orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ google-services.json
 
 # Android Profiling
 *.hprof
+/app/release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
 

--- a/app/src/main/java/com/example/android/camera2/basic/fragments/CameraFragment.kt
+++ b/app/src/main/java/com/example/android/camera2/basic/fragments/CameraFragment.kt
@@ -474,6 +474,14 @@ class CameraFragment : Fragment() {
                                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
                             }
 
+                            // Add EXIF orientation data using the URI
+                            resolver.openFileDescriptor(uri, "rw")?.use { pfd ->
+                                ExifInterface(pfd.fileDescriptor).apply {
+                                    setAttribute(ExifInterface.TAG_ORIENTATION, result.orientation.toString())
+                                    saveAttributes()
+                                }
+                            }
+
                             // Create a reference file in the DCIM directory
                             val dcim = Environment.getExternalStoragePublicDirectory(
                                 Environment.DIRECTORY_DCIM
@@ -492,6 +500,12 @@ class CameraFragment : Fragment() {
 
                             FileOutputStream(file).use { stream ->
                                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+                            }
+
+                            // Add EXIF orientation data
+                            ExifInterface(file.absolutePath).apply {
+                                setAttribute(ExifInterface.TAG_ORIENTATION, result.orientation.toString())
+                                saveAttributes()
                             }
 
                             cont.resume(file)


### PR DESCRIPTION
This pull request includes changes to the `app/build.gradle` and `CameraFragment.kt` files to improve the build configuration and the handling of EXIF orientation data for images.
Build configuration:

* [`app/build.gradle`](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9R47): Added `signingConfig` to the release configuration to use the debug signing configuration. 

Handling of EXIF orientation data:

* [`app/src/main/java/com/example/android/camera2/basic/fragments/CameraFragment.kt`](diffhunk://#diff-ad9f640003a71a6dfb51f97d095ea37a4f48f82796559d3a417ece2bce7e786fR477-R484): Added code to insert EXIF orientation data using a URI. Closes #4 
* [`app/src/main/java/com/example/android/camera2/basic/fragments/CameraFragment.kt`](diffhunk://#diff-ad9f640003a71a6dfb51f97d095ea37a4f48f82796559d3a417ece2bce7e786fR505-R510): Added code to insert EXIF orientation data using the file's absolute path. Closes #4 